### PR TITLE
Fixed ipv6 icmp

### DIFF
--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -108,7 +108,7 @@ if [ -x "$(which ip6tables 2>/dev/null)" ]; then
   {% endfor %}
 
   # Accept icmp ping requests.
-  ip6tables -A INPUT -p icmp -j ACCEPT
+  ip6tables -A INPUT -p ipv6-icmp -j ACCEPT
 
   # Allow NTP traffic for time synchronization.
   ip6tables -A OUTPUT -p udp --dport 123 -j ACCEPT


### PR DESCRIPTION
Need ip6tables to accept ipv6-icmp not icmp.

The ip6tables command accepts the argument icmp (because it is a valid protocol in /etc/protocols), but the icmp protocol does not make sense in a ipv6 chain. You want ipv6-icmp instead!

This could lead to some hard to find bugs in dual stacked networks.